### PR TITLE
Handle cases where a route's prefix is a nested URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#756](https://github.com/ruby-grape/grape-swagger/pull/756): Fix reference creation when custom type for documentation is provided - [@bikolya](https://github.com/bikolya).
 
 ### 0.33.0 (June 21, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#757](https://github.com/ruby-grape/grape-swagger/pull/757): Fix `array_use_braces` for nested body params - [@bikolya](https://github.com/bikolya).
 * [#756](https://github.com/ruby-grape/grape-swagger/pull/756): Fix reference creation when custom type for documentation is provided - [@bikolya](https://github.com/bikolya).
 
 ### 0.33.0 (June 21, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#758](https://github.com/ruby-grape/grape-swagger/pull/758): Handle cases where a route's prefix is a nested URL - [@SimonKaluza](https://github.com/simonkaluza).
 * [#757](https://github.com/ruby-grape/grape-swagger/pull/757): Fix `array_use_braces` for nested body params - [@bikolya](https://github.com/bikolya).
 * [#756](https://github.com/ruby-grape/grape-swagger/pull/756): Fix reference creation when custom type for documentation is provided - [@bikolya](https://github.com/bikolya).
 

--- a/lib/grape-swagger/doc_methods/extensions.rb
+++ b/lib/grape-swagger/doc_methods/extensions.rb
@@ -87,7 +87,12 @@ module GrapeSwagger
           part.select { |x| x == identifier }
         end
 
-        def method
+        def method(*args)
+          # We're shadowing Object.method(:symbol) here so we provide
+          # a compatibility layer for code that introspects the methods
+          # of this class
+          return super if args.size.positive?
+
           @route.request_method.downcase.to_sym
         end
       end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -178,10 +178,10 @@ module Grape
       parameters = partition_params(route, options).map do |param, value|
         value = { required: false }.merge(value) if value.is_a?(Hash)
         _, value = default_type([[param, value]]).first if value == ''
-        if value[:type]
-          expose_params(value[:type])
-        elsif value[:documentation]
+        if value.dig(:documentation, :type)
           expose_params(value[:documentation][:type])
+        elsif value[:type]
+          expose_params(value[:type])
         end
         GrapeSwagger::DocMethods::ParseParams.call(param, value, path, route, @definitions)
       end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -251,10 +251,10 @@ module Grape
     def tag_object(route, path)
       version = GrapeSwagger::DocMethods::Version.get(route)
       version = [version] unless version.is_a?(Array)
-
+      prefix = route.prefix.to_s.split('/').reject(&:empty?)
       Array(
         path.split('{')[0].split('/').reject(&:empty?).delete_if do |i|
-          i == route.prefix.to_s || version.map(&:to_s).include?(i)
+          prefix.include?(i) || version.map(&:to_s).include?(i)
         end.first
       ).presence
     end

--- a/lib/grape-swagger/endpoint/params_parser.rb
+++ b/lib/grape-swagger/endpoint/params_parser.rb
@@ -15,17 +15,14 @@ module GrapeSwagger
       end
 
       def parse_request_params
-        array_keys = []
         public_params.each_with_object({}) do |(name, options), memo|
           name = name.to_s
           param_type = options[:type]
           param_type = param_type.to_s unless param_type.nil?
 
           if param_type_is_array?(param_type)
-            array_keys << name
             options[:is_array] = true
-
-            name += '[]' if array_use_braces?(options)
+            name += '[]' if array_use_braces?
           end
 
           memo[name] = options
@@ -34,8 +31,8 @@ module GrapeSwagger
 
       private
 
-      def array_use_braces?(options)
-        settings[:array_use_braces] && !(options[:documentation] && options[:documentation][:param_type] == 'body')
+      def array_use_braces?
+        @array_use_braces ||= settings[:array_use_braces] && !includes_body_param?
       end
 
       def param_type_is_array?(param_type)
@@ -60,6 +57,12 @@ module GrapeSwagger
         param_hidden = param_options[:documentation].fetch(:hidden, false)
         param_hidden = param_hidden.call if param_hidden.is_a?(Proc)
         !param_hidden
+      end
+
+      def includes_body_param?
+        params.any? do |_, options|
+          options.dig(:documentation, :param_type) == 'body' || options.dig(:documentation, :in) == 'body'
+        end
       end
     end
   end

--- a/spec/lib/endpoint/params_parser_spec.rb
+++ b/spec/lib/endpoint/params_parser_spec.rb
@@ -56,13 +56,53 @@ describe GrapeSwagger::Endpoint::ParamsParser do
     end
 
     context 'when param is nested in a param of hash type' do
-      let(:params) { [['param_1', { type: 'Hash' }], ['param_1[param_2]', { type: 'String' }]] }
+      let(:params) { [param_1, param_2] }
+      let(:param_1) { ['param_1', { type: 'Hash' }] }
+      let(:param_2) { ['param_1[param_2]', { type: 'String' }] }
 
       context 'and array_use_braces setting set to true' do
         let(:settings) { { array_use_braces: true } }
 
-        it 'does not add braces to the param key' do
-          expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+        context 'and param is of simple type' do
+          it 'does not add braces to the param key' do
+            expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+          end
+        end
+
+        context 'and param is of array type' do
+          let(:param_2) { ['param_1[param_2]', { type: 'Array[String]' }] }
+
+          it 'adds braces to the param key' do
+            expect(parse_request_params.keys.last).to eq 'param_1[param_2][]'
+          end
+
+          context 'and `param_type` option is set to body' do
+            let(:param_2) do
+              ['param_1[param_2]', { type: 'Array[String]', documentation: { param_type: 'body' } }]
+            end
+
+            it 'does not add braces to the param key' do
+              expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+            end
+          end
+
+          context 'and `in` option is set to body' do
+            let(:param_2) do
+              ['param_1[param_2]', { type: 'Array[String]', documentation: { in: 'body' } }]
+            end
+
+            it 'does not add braces to the param key' do
+              expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+            end
+          end
+
+          context 'and hash `param_type` option is set to body' do
+            let(:param_1) { ['param_1', { type: 'Hash', documentation: { param_type: 'body' } }] }
+
+            it 'does not add braces to the param key' do
+              expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+            end
+          end
         end
       end
     end

--- a/spec/lib/extensions_spec.rb
+++ b/spec/lib/extensions_spec.rb
@@ -3,6 +3,16 @@
 require 'spec_helper'
 
 describe GrapeSwagger::DocMethods::Extensions do
+  context 'it should not break method introspection' do
+    describe '.method' do
+      describe 'method introspection' do
+        specify do
+          expect(described_class.method(described_class.methods.first)).to be_a(Method)
+        end
+      end
+    end
+  end
+
   describe '#find_definition' do
     subject { described_class }
 

--- a/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
@@ -10,7 +10,9 @@ describe 'document hash and array' do
       class TestApi < Grape::API
         format :json
 
-        documentation = ::Entities::DocumentedHashAndArrayModel.documentation if ::Entities::DocumentedHashAndArrayModel.respond_to?(:documentation)
+        if ::Entities::DocumentedHashAndArrayModel.respond_to?(:documentation)
+          documentation = ::Entities::DocumentedHashAndArrayModel.documentation
+        end
 
         desc 'This returns something'
         namespace :arbitrary do

--- a/spec/swagger_v2/endpoint_versioned_path_spec.rb
+++ b/spec/swagger_v2/endpoint_versioned_path_spec.rb
@@ -52,6 +52,39 @@ describe 'Grape::Endpoint#path_and_definitions' do
         expect(subject.first['/v1/item'][:get][:tags]).to eq ['special-item']
       end
     end
+
+    context 'when parameter with a custom type is specified' do
+      let(:item) do
+        Class.new(Grape::API) do
+          Color = Struct.new(:value) do
+            def self.parse(value)
+              new(value: value)
+            end
+          end
+
+          class ColorEntity < Grape::Entity
+            expose :value
+          end
+
+          version 'v1', using: :path
+
+          resource :item do
+            params do
+              requires :root, type: Hash do
+                optional :color, type: Color, documentation: { type: ColorEntity }
+              end
+            end
+            post '/'
+          end
+        end
+      end
+
+      it 'creates a reference to the model instead of using the non-existent type' do
+        color = subject.dig(1, 'postV1Item', :properties, :root, :properties, :color)
+        expect(color).not_to eq(type: 'ColorEntity')
+        expect(color).to eq('$ref' => '#/definitions/ColorEntity')
+      end
+    end
   end
 
   context 'when mounting an API more than once', if: GrapeVersion.satisfy?('>= 1.2.0') do

--- a/spec/swagger_v2/namespace_tags_prefix_spec.rb
+++ b/spec/swagger_v2/namespace_tags_prefix_spec.rb
@@ -29,12 +29,25 @@ describe 'namespace tags check while using prefix and version' do
           end
         end
       end
+
+      class NestedPrefixApi < Grape::API
+        version :v1
+        prefix 'nested_prefix/api'
+
+        namespace :deep_namespace do
+          desc 'This gets something within a deeply nested resource'
+          get '/deep' do
+            { bla: 'something' }
+          end
+        end
+      end
     end
 
     class TagApi < Grape::API
       prefix :api
       mount TheApi::CascadingVersionApi
       mount TheApi::NamespaceApi
+      mount TheApi::NestedPrefixApi
       add_swagger_documentation
     end
   end
@@ -55,7 +68,8 @@ describe 'namespace tags check while using prefix and version' do
           { 'name' => 'hudson', 'description' => 'Operations about hudsons' },
           { 'name' => 'colorado', 'description' => 'Operations about colorados' },
           { 'name' => 'thames', 'description' => 'Operations about thames' },
-          { 'name' => 'niles', 'description' => 'Operations about niles' }
+          { 'name' => 'niles', 'description' => 'Operations about niles' },
+          { 'name' => 'deep_namespace', 'description' => 'Operations about deep_namespaces' }
         ]
       )
 


### PR DESCRIPTION
Nested prefixes (any prefix containing a '/' character) prior to this commit would incorrectly get tagged as the first segment of the URL prefix.

E.g. a route like "api/beta/v1/patients" would incorrectly get tagged as "api" instead of "patients"